### PR TITLE
Bugfix: convert keys to list

### DIFF
--- a/bin/gtf2bed.py
+++ b/bin/gtf2bed.py
@@ -196,7 +196,7 @@ for annotationSource in sources:
                     cds[txIter - 1]['end'] = int(end)
 
     cdsRank = cds.keys()
-    exonRank = exon.keys()
+    exonRank = list(exon.keys())
 
     if len(cdsRank) == 0:
         if (curStrand == "+") :


### PR DESCRIPTION
Fixes "AttributeError: 'dict_keys' object has no attribute 'index'" that occurred when using iGenomes GRCh38 Line 92 already wraps exon.keys() in list() - this seems to have been forgotten in line 199.

# nf-core/slamseq pull request

Many thanks for contributing to nf-core/slamseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If necessary, also make a PR on the [nf-core/slamseq branch on the nf-core/test-datasets repo](https://github.com/nf-core/test-datasets/pull/new/nf-core/slamseq)
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [x] Make sure your code lints (`nf-core lint .`).

**Learn more about contributing:** [CONTRIBUTING.md](https://github.com/nf-core/slamseq/tree/master/.github/CONTRIBUTING.md)
